### PR TITLE
Returning missing error info

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,8 +77,20 @@ function sudoCommand(command, password, withResult, callback) {
                     spawnProcess.stdin.write(password + "\n");
                 }
             }
+            if (errorFound(line)) {
+                if(error === null) {
+                    error = ''
+                }
+                error += data.toString().trim() // In case script throws multiple errors
+                // error = new Error(data.toString().trim())
+            }
         });
     });
+}
+
+function errorFound(line) {
+    const errors = ['E: Invalid operation', 'could not be found', 'command not found', 'Invalid subcommand'];
+    return errors.filter(err => line.includes(err)).length ? true : false
 }
 
 function sudoCommandForWindows(command, withResult, callback) {


### PR DESCRIPTION
In Ubuntu 18.04
"error" in callback seems to be `null` even if the command failed
Returning error info if errors related to these are found, ['E: Invalid operation', 'could not be found', 'command not found', 'Invalid subcommand']